### PR TITLE
GE Built In AC Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+bin/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -109,6 +110,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+pyvenv.cfg
 
 # Spyder project settings
 .spyderproject

--- a/gehomesdk/erd/values/common/erd_appliance_type.py
+++ b/gehomesdk/erd/values/common/erd_appliance_type.py
@@ -29,3 +29,4 @@ class ErdApplianceType(enum.Enum):
     CAFE_COFFEE_MAKER = "1A"
     OPAL_ICE_MAKER = "1B"
     DEHUMIDIFIER = "1D"
+    BUILT_IN_AIR_CONDITIONER = "1F"


### PR DESCRIPTION
Adding appliance ERD type support for Built In GE Air conditioners with WI-FI enabled

Tested the following models: 

AJCQ08AWH, AJCQ10AWH, AJCQ12AWH

AJCQ08AWHK1, AJCQ10AWHK1, AJCQ12AWHK1
https://www.geappliances.com/appliance/GE-115-Volt-Built-In-Cool-Only-Room-Air-Conditioner-AJCQ12AWH

These models were able to correctly populate existing ERD attributes below, with example values:

```
ErdCode.MODEL_NUMBER: AJCQ12AWHK1
ErdCode.SERIAL_NUMBER: 00000000
ErdCode.TEMPERATURE_UNIT: ErdMeasurementUnits.IMPERIAL
ErdCode.APPLIANCE_TYPE: ErdApplianceType.BUILT_IN_AIR_CONDITIONER
ErdCode.UNIT_TYPE: ErdUnitType.UNKNOWN
ErdCode.WIFI_MODULE_UPDATING: True
ErdCode.WIFI_MODULE_SW_VERSION: 0.1.11.50
ErdCode.WIFI_MODULE_SW_VERSION_AVAILABLE: 0.0.0.0
ErdCode.ACM_UPDATING: False
ErdCode.APPLIANCE_SW_VERSION: 0.0.0.0
ErdCode.APPLIANCE_SW_VERSION_AVAILABLE: 0.0.0.0
ErdCode.APPLIANCE_UPDATING: False
ErdCode.AC_TARGET_TEMPERATURE: 72
ErdCode.AC_FAN_SETTING: ErdAcFanSetting.LOW
ErdCode.AC_OPERATION_MODE: ErdAcOperationMode.ENERGY_SAVER
ErdCode.AC_AMBIENT_TEMPERATURE: 74
ErdCode.AC_FILTER_STATUS: ErdAcFilterStatus.OK
ErdCode.AC_POWER_STATUS: ErdOnOff.ON
ErdCode.SAC_AVAILABLE_MODES: ErdSacAvailableModes(has_heat=False, has_dry=True, has_eco=True, raw_value='06')
ErdCode.WAC_DEMAND_RESPONSE_POWER: 0.267
ErdCode.WAC_DEMAND_RESPONSE_STATE: ErdWacDemandResponseState.NOT_IN_DEMAND_RESPONSE
```