### PR TITLE
Convert EcoDry Status Value

### DIFF
--- a/gehomesdk/erd/erd_configuration.py
+++ b/gehomesdk/erd/erd_configuration.py
@@ -190,6 +190,7 @@ _configuration = [
     ErdConfigurationEntry(ErdCode.LAUNDRY_DRYER_DAMP_ALERT, ErdReadOnlyBoolConverter(), ErdCodeClass.LAUNDRY_DRYER_SENSOR, ErdDataType.BOOL),
     ErdConfigurationEntry(ErdCode.LAUNDRY_DRYER_REDUCE_STATIC, ErdReadOnlyBoolConverter(), ErdCodeClass.LAUNDRY_DRYER_SENSOR, ErdDataType.BOOL),
     ErdConfigurationEntry(ErdCode.LAUNDRY_DRYER_WASHERLINK_STATUS, ErdReadOnlyBoolConverter(), ErdCodeClass.LAUNDRY_DRYER_SENSOR, ErdDataType.BOOL),
+    ErdConfigurationEntry(ErdCode.LAUNDRY_DRYER_ECODRY_STATUS, EcoDryStatusConverter(), ErdCodeClass.LAUNDRY_DRYER_SENSOR, ErdDataType.BOOL),
 
     # Microwave
     ErdConfigurationEntry(ErdCode.MICROWAVE_REMOTE_ENABLE, ErdReadOnlyBoolConverter(), ErdCodeClass.MICROWAVE_SENSOR, ErdDataType.BOOL),


### PR DESCRIPTION
The ErdConfigurationEntry for LAUNDRY_DRYER_ECODRY_STATUS was missing.

This resulted in EcoDry Status showing as bytes rather than the enum which already existed.

Before:
2023-04-25 14:41:44,913 DEBUG    Setting ErdCode.LAUNDRY_DRYER_ECODRY_STATUS to b'\x00\x03'
After:
2023-04-25 14:56:39,349 DEBUG    Setting ErdCode.LAUNDRY_DRYER_ECODRY_STATUS to Disabled