### PR TITLE
Dehumidifier Current Humidity Value Fix

### DIFF
--- a/gehomesdk/__init__.py
+++ b/gehomesdk/__init__.py
@@ -1,6 +1,6 @@
 """GE Home SDK"""
 
-__version__ = "0.5.13"
+__version__ = "0.5.14"
 
 
 from .clients import *

--- a/gehomesdk/erd/converters/dehumidifier/__init__.py
+++ b/gehomesdk/erd/converters/dehumidifier/__init__.py
@@ -1,1 +1,2 @@
 from .erd_dehumidifier_maintenance_converter import ErdDehumidifierMaintenanceConverter
+from .erd_dehumidifier_current_humidity_converter import ErdDehumidifierCurrentHumidityConverter

--- a/gehomesdk/erd/converters/dehumidifier/erd_dehumidifier_current_humidity_converter.py
+++ b/gehomesdk/erd/converters/dehumidifier/erd_dehumidifier_current_humidity_converter.py
@@ -1,0 +1,10 @@
+from ..abstract import ErdReadWriteConverter
+from ..primitives import *
+
+
+class ErdDehumidifierCurrentHumidityConverter(ErdReadWriteConverter[int]):
+    def erd_decode(self, value: str) -> int:
+        try:
+            return erd_decode_int(value) & 0xFF
+        except:
+            return 0

--- a/gehomesdk/erd/erd_configuration.py
+++ b/gehomesdk/erd/erd_configuration.py
@@ -265,7 +265,7 @@ _configuration = [
 
     #Dehumidifier
     ErdConfigurationEntry(ErdCode.DHUM_TARGET_HUMIDITY, ErdIntConverter(), ErdCodeClass.DEHUMIDIFIER_SENSOR, ErdDataType.INT),
-    ErdConfigurationEntry(ErdCode.DHUM_CURRENT_HUMIDITY, ErdReadOnlyIntConverter(), ErdCodeClass.DEHUMIDIFIER_SENSOR, ErdDataType.INT),
+    ErdConfigurationEntry(ErdCode.DHUM_CURRENT_HUMIDITY, ErdDehumidifierCurrentHumidityConverter(), ErdCodeClass.DEHUMIDIFIER_SENSOR, ErdDataType.INT),
     ErdConfigurationEntry(ErdCode.DHUM_MAINTENANCE, ErdDehumidifierMaintenanceConverter(), ErdCodeClass.DEHUMIDIFIER_SENSOR),
 
     #Hood


### PR DESCRIPTION
The Dehumidifier "Current Humidity" values are showing incorrect values. For example:
`Setting ErdCode.DHUM_CURRENT_HUMIDITY to 306`
The values correspond to the following actual values
45% -> 301,
50% -> 306,
55% -> 311,
60% -> 316

The value seemed to only need to consider the first byte. I'm not entirely sure if this is the desired fix but I created a converter to do this and was receiving the correct value when running the `websocket_example.py` script afterwards:
`Setting ErdCode.DHUM_CURRENT_HUMIDITY to 50`