### PR TITLE
fix(oven): treat burners as dict

### DIFF
--- a/gehomesdk/erd/converters/oven/cooktop_status_ext_converter.py
+++ b/gehomesdk/erd/converters/oven/cooktop_status_ext_converter.py
@@ -24,7 +24,7 @@ class CooktopStatusExtConverter(ErdReadOnlyConverter[CooktopStatus]):
             burners["rightRear"] = Burner(self._convert_to_legacy(vals[15]), 0)
 
             status = ErdCooktopStatus.OFF
-            if(any(x.on for x in burners)):
+            if(any(x.on for _,x in burners.items())):
                 status = ErdCooktopStatus.BURNERS_ON
 
             return CooktopStatus(status, burners, value)


### PR DESCRIPTION
Corrects syntax so burners is treated as a dictionary.

Fixes https://github.com/simbaja/gehome/issues/58 and https://github.com/simbaja/ha_gehome/issues/201