### PR TITLE
Add additional Erd codes for coffee maker

### DIFF
--- a/gehomesdk/erd/erd_codes.py
+++ b/gehomesdk/erd/erd_codes.py
@@ -389,5 +389,8 @@ class ErdCode(enum.Enum):
     CCM_IS_DESCALING = "0x9019"
     CCM_START_DESCALING = "0x901a"
     CCM_CANCEL_DESCALING = "0x901b"
+    CCM_EMPTY_WASTE_BIN = "0x902c"
+    CCM_OUT_OF_BEANS = "0x902d"
+    CCM_DESCALE_REQUIRED = "0x9030"
 
 ErdCodeType = Union[ErdCode, str]

--- a/gehomesdk/erd/erd_configuration.py
+++ b/gehomesdk/erd/erd_configuration.py
@@ -300,4 +300,7 @@ _configuration = [
     ErdConfigurationEntry(ErdCode.CCM_IS_DESCALING, ErdReadOnlyBoolConverter(), ErdCodeClass.CCM_SENSOR, ErdDataType.BOOL),
     ErdConfigurationEntry(ErdCode.CCM_START_DESCALING, ErdBoolConverter(), ErdCodeClass.CCM_SENSOR, ErdDataType.BOOL),
     ErdConfigurationEntry(ErdCode.CCM_CANCEL_DESCALING, ErdBoolConverter(), ErdCodeClass.CCM_SENSOR, ErdDataType.BOOL),
+    ErdConfigurationEntry(ErdCode.CCM_EMPTY_WASTE_BIN, ErdBoolConverter(), ErdCodeClass.CCM_SENSOR, ErdDataType.BOOL),
+    ErdConfigurationEntry(ErdCode.CCM_OUT_OF_BEANS, ErdBoolConverter(), ErdCodeClass.CCM_SENSOR, ErdDataType.BOOL),
+    ErdConfigurationEntry(ErdCode.CCM_DESCALE_REQUIRED, ErdBoolConverter(), ErdCodeClass.CCM_SENSOR, ErdDataType.BOOL),
 ]


### PR DESCRIPTION
This adds three codes, got them from .smali in Smart HQ apk version 1.0.0.102.12

- Empty Waste Bin
- Out of Beans
- Descale required

Tested with GE Profile Automatic Espresso Machine (Model P7CEBBS6RBB)