### PR TITLE
Remove extra comma from UserCycleSetting enum

### DIFF
--- a/gehomesdk/erd/values/dishwasher/erd_user_setting.py
+++ b/gehomesdk/erd/values/dishwasher/erd_user_setting.py
@@ -15,7 +15,7 @@ class UserCycleSetting(enum.Enum):
     DELICATE = 3
     THIRTY_MIN = 4
     ECO = 5
-    RINSE = 6,
+    RINSE = 6
     FP_UNKNOWN = 7
 
 @enum.unique


### PR DESCRIPTION
It was added by commit 62edb2b, and seems to be the cause of the error `ValueError: 6 is not a valid UserCycleSetting`