### PR TITLE
Adding new dishwasher operating mode enum value and fixing handling of unknown values

### DIFF
--- a/gehomesdk/erd/converters/dishwasher/operating_mode_converter.py
+++ b/gehomesdk/erd/converters/dishwasher/operating_mode_converter.py
@@ -14,4 +14,4 @@ class OperatingModeConverter(ErdReadOnlyConverter[OperatingMode]):
             _LOGGER.debug(f'raw operating mode value: {om}')
             return OPERATING_MODE_MAP[om]
         except (KeyError, ValueError):
-            return ErdOperatingMode.NA
+            return ErdOperatingMode.INVALID

--- a/gehomesdk/erd/values/dishwasher/erd_operating_mode.py
+++ b/gehomesdk/erd/values/dishwasher/erd_operating_mode.py
@@ -12,6 +12,7 @@ class ErdOperatingMode(enum.Enum):
     DOWNLOAD_MODE = 7
     SENSOR_CHECK_MODE = 8
     LOAD_ACTIVATION_MODE = 9
+    OFF = 11
     MC_ONLY_MODE = 17
     WARNING_MODE = 18
     CONTROL_LOCKED = 19


### PR DESCRIPTION
The library was throwing 2x exceptions when gathering data on my dishwasher. The first was a `ValueError: 11 is not a valid ErdOperatingMode` error, and the second a `AttributeError: type object 'ErdOperatingMode' has no attribute 'NA'` error.

The GE app shows my dishwasher in an `OFF` state, so I add that as the enum value for `11`. 
I then corrected the fallback from using the non-existing `NA` enum value to the present `INVALID` enum value. This also matches fallback behavior for other data types like `ErdLaundryCycle`.