### PR TITLE
Add support to pass SSL context.

### DIFF
--- a/gehomesdk/__init__.py
+++ b/gehomesdk/__init__.py
@@ -1,6 +1,6 @@
 """GE Home SDK"""
 
-__version__ = "0.5.28"
+__version__ = "0.5.29"
 
 
 from .clients import *


### PR DESCRIPTION
Resolves #73 by accepting an ssl_context object (so we can use the default one provided by Home-Assistant)