### PR TITLE
Add value for new 'soft freeze' mode on fridge convertible drawers

### DIFF
--- a/gehomesdk/erd/values/fridge/erd_convertable_drawer_mode.py
+++ b/gehomesdk/erd/values/fridge/erd_convertable_drawer_mode.py
@@ -5,6 +5,7 @@ from typing import Optional
 class ErdConvertableDrawerMode(enum.Enum):
     UNKNOWN0 = "00"
     UNKNOWN1 = "01"
+    SOFT_FREEZE = "02"
     MEAT = "03"
     BEVERAGE = "04"
     SNACK = "05"


### PR DESCRIPTION
A new value for convertible drawers was observed in the app, and it corresponds to this new value. Tested on a Cafe 4-drawer fridge.

This looks like it ought to fix https://github.com/simbaja/ha_gehome/issues/295 