### PR TITLE
Laundry Cycle Enum Additions

### DIFF
--- a/gehomesdk/erd/values/laundry/laundry_enums.py
+++ b/gehomesdk/erd/values/laundry/laundry_enums.py
@@ -60,7 +60,13 @@ class ErdLaundryCycle(enum.Enum):
     SANITIZE_WITH_OXI = 30
     SELF_CLEAN = 31
     TOWEL = 32
+    WOOL = 34
     ULTRAFRESH_VENT = 35
+    SPIN = 37
+    EVERYDAY = 38
+    DRUM_CLEAN = 44
+    QUICK = 47
+    EASY_IRON = 48
     COTTONS = 128
     EASY_CARE = 129
     ACTIVE_WEAR = 130


### PR DESCRIPTION
Just bought a new Fisher and Paykel 10kg Washer (WH1060P4AA)

Added 6 additional missing cycle enums matched to the SmartHQ cycle names
