### PR TITLE
Add log entry when laundry cycle value is not a defined enum

### DIFF
--- a/gehomesdk/erd/converters/laundry/laundry_cycle_converter.py
+++ b/gehomesdk/erd/converters/laundry/laundry_cycle_converter.py
@@ -11,4 +11,5 @@ class ErdLaundryCycleConverter(ErdReadOnlyConverter[ErdLaundryCycle]):
         try:
             return ErdLaundryCycle(erd_decode_int(value))
         except (KeyError, ValueError):
+            _LOGGER.info(f"Unknown laundry cycle found, value = {value}")
             return ErdLaundryCycle.NOT_DEFINED

--- a/gehomesdk/erd/values/laundry/laundry_enums.py
+++ b/gehomesdk/erd/values/laundry/laundry_enums.py
@@ -148,7 +148,7 @@ class ErdLaundryCycle(enum.Enum):
     RESET = 255
 
     def stringify(self, **kwargs):
-        if self == ErdLaundryCycle.INVALID:
+        if self == ErdLaundryCycle.NOT_DEFINED:
             return "---"
         return self.name.replace("_"," ").replace("2", "").title()      
 


### PR DESCRIPTION
* Add a log entry when a laundry cycle value is not a defined enum.
* Fixed previously missed change from INVALID to NOT_DEFINED for greater consistency with GE Home API.