### PR TITLE
Fix fridge HOT_WATER_SET_TEMP

### DIFF
--- a/gehomesdk/erd/erd_configuration.py
+++ b/gehomesdk/erd/erd_configuration.py
@@ -50,7 +50,7 @@ _configuration = [
     ErdConfigurationEntry(ErdCode.PERSONALITY, ErdPersonalityConverter(), ErdCodeClass.GENERAL),
 
     #Fridge
-    ErdConfigurationEntry(ErdCode.HOT_WATER_SET_TEMP, ErdIntConverter(), ErdCodeClass.NON_ZERO_TEMPERATURE, ErdDataType.INT),
+    ErdConfigurationEntry(ErdCode.HOT_WATER_SET_TEMP, ErdIntConverter(length=1), ErdCodeClass.NON_ZERO_TEMPERATURE, ErdDataType.INT),
     ErdConfigurationEntry(ErdCode.HOT_WATER_IN_USE, ErdReadOnlyBoolConverter(), ErdCodeClass.DISPENSER_SENSOR, ErdDataType.BOOL),
     ErdConfigurationEntry(ErdCode.TURBO_FREEZE_STATUS, ErdBoolConverter(), ErdCodeClass.COOLING_CONTROL, ErdDataType.BOOL),
     ErdConfigurationEntry(ErdCode.TURBO_COOL_STATUS, ErdBoolConverter(), ErdCodeClass.COOLING_CONTROL, ErdDataType.BOOL),


### PR DESCRIPTION
This change was discussed in https://github.com/simbaja/ha_gehome/issues/101 and looks like it might have been implemented, then later reverted because it seemingly didn't work, but I suspect that was user error (like the change wasn't actually carried all the way through from library -> ha_gehome release -> that person updating, etc), or there's a secondary issue in ha_gehome.

I have a Cafe fridge with the K-Cup brewer... changing this definitely fixes the setting the temperature for me, using your library/websocket example directly.

The API ["docs"](https://raw.githubusercontent.com/geappliances/public-appliance-api-documentation/refs/heads/main/appliance_api_erd_definitions.json) show they expect an unsigned 8-bit integer for `0x1011`:

```javascript
{
    "name": "Hot Water Desired Temperature",
    "id": "0x1011",
    "operations": ["read", "write", "publish", "subscribe"],
    "description": "Used to read or write the desired temperature of the hot water.  Legacy ERD that it does not follow Request/Status ERDs' architecture. ERD 0x1018 should be read before writing this ERD. Temperature should only be written when ERD 0x1018 status is 0 (Available). ERD should not be used when ERD 0x1010 status is 255 (Not Applicable).",
    "updateClass": {
      "type": "legacy"
    },
    "data": [{
      "name": "Hot Water Desired Temperature (fahrenheit)",
      "type": "u8",
      "offset": 0,
      "size": 1
    }]
  }
```

While the default for `ErdIntConverter` is length=2 (bytes):

```python
class ErdIntConverter(ErdReadWriteConverter[int]):
    def __init__(self, erd_code: ErdCodeType = "Unknown", length: int = 2):
```

 so setting this ERD currently sends 2 bytes.  I added some logging to see the full request/response, and when sending 2 bytes the response is always a timeout (10 seconds later, since that's what is asked for):

```javascript
{
  'kind': 'websocket#api',
  'id': 'XXXXXXXXXXXX-setErd-0x1011',
  'request': {
    'host': 'api.brillion.geappliances.com',
    'method': 'POST',
    'path': '/v1/appliance/XXXXXXXXXXXX/erd/0x1011'
  },
  'success': True,
  'code': 200,
  'body': {'status': 'timeout'}
}
```

Changing it to one byte works for me:

```javascript
{
  'kind': 'websocket#api',
  'id': 'XXXXXXXXXXXX-setErd-0x1011',
  'request': {
    'host': 'api.brillion.geappliances.com',
    'method': 'POST',
    'path': '/v1/appliance/XXXXXXXXXXXX/erd/0x1011'
  },
  'success': True,
  'code': 200,
  'body': {'status': 'success'}
}
```

Even if this change doesn't work for everybody, I expect it to be at worst harmless, since it doesn't seem like sending 2 bytes for this ERD can ever do anything useful.