### PR TITLE
Add get_raw_erd_value() for appliance-specific ERD decoding

### DIFF
--- a/gehomesdk/ge_appliance.py
+++ b/gehomesdk/ge_appliance.py
@@ -43,6 +43,7 @@ class GeAppliance:
         self._mac_addr = mac_addr.upper()
         self._message_id = 0
         self._property_cache = {}  # type: Dict[ErdCodeType, Any]
+        self._raw_property_cache = {}  # type: Dict[ErdCodeType, str]
         self._features = []
         self.client = client
         self.initialized = False
@@ -134,6 +135,22 @@ class GeAppliance:
         erd_code = self._encoder.translate_code(erd_code)
         return self._property_cache[erd_code]
 
+    def get_raw_erd_value(self, erd_code: ErdCodeType) -> Optional[str]:
+        """
+        Get the raw hex string last received for this ERD, or None if never received.
+
+        Useful when a device uses an ERD hex code outside the semantics its upstream
+        converter assumes (e.g. a standalone gas cooktop that reuses a hex code
+        already registered for an oven/hood with different byte meaning). The raw
+        cache lets the consumer decode the bytes against the actual device's schema
+        instead of whatever shape the global converter produced.
+
+        :param erd_code: ErdCode or str, the ERD code whose raw value we want
+        :return: The raw hex string as received from the appliance, or None
+        """
+        erd_code = self._encoder.translate_code(erd_code)
+        return self._raw_property_cache.get(erd_code)
+
     def get_erd_code_class(self, erd_code: ErdCodeType) -> ErdCodeClass:
         """
         Get the classification for a given ErdCode
@@ -165,6 +182,8 @@ class GeAppliance:
         """
         erd_code = self._encoder.translate_code(erd_code)
         value = self.decode_erd_value(erd_code, erd_value)
+
+        self._raw_property_cache[erd_code] = erd_value
 
         old_value = self._property_cache.get(erd_code)
 

--- a/tests/test_raw_erd_value.py
+++ b/tests/test_raw_erd_value.py
@@ -1,0 +1,41 @@
+"""Tests for GeAppliance.get_raw_erd_value()."""
+from unittest.mock import MagicMock
+
+from gehomesdk import ErdCode
+from gehomesdk.ge_appliance import GeAppliance
+
+
+def _make_appliance(mac: str) -> GeAppliance:
+    client = MagicMock()
+    client.client_priority = 0
+    return GeAppliance(mac, client)
+
+
+def test_raw_value_returns_none_when_never_received():
+    appliance = _make_appliance("00:00:00:00:00:01")
+    assert appliance.get_raw_erd_value("0x5900") is None
+    assert appliance.get_raw_erd_value(ErdCode.USER_INTERFACE_LOCKED) is None
+
+
+def test_raw_value_round_trip_for_unregistered_code():
+    """Unregistered hex codes preserve their raw wire value verbatim."""
+    appliance = _make_appliance("00:00:00:00:00:02")
+    appliance.update_erd_value("0x5900", "03")
+    assert appliance.get_raw_erd_value("0x5900") == "03"
+
+
+def test_raw_value_round_trip_for_registered_code():
+    """Registered codes (decoded by an upstream converter) also preserve
+    the raw bytes — the decoded cache and the raw cache live in parallel."""
+    appliance = _make_appliance("00:00:00:00:00:03")
+    appliance.update_erd_value(ErdCode.USER_INTERFACE_LOCKED, "01")
+    assert appliance.get_raw_erd_value(ErdCode.USER_INTERFACE_LOCKED) == "01"
+    # lookup by equivalent hex string resolves to the same entry
+    assert appliance.get_raw_erd_value("0x0004") == "01"
+
+
+def test_raw_value_is_overwritten_on_update():
+    appliance = _make_appliance("00:00:00:00:00:04")
+    appliance.update_erd_value("0x5900", "01")
+    appliance.update_erd_value("0x5900", "03")
+    assert appliance.get_raw_erd_value("0x5900") == "03"


### PR DESCRIPTION
## Problem

`ErdCode` is a flat, appliance-type-agnostic enum — each hex code is registered once with one converter. Some appliances reuse existing hex codes with different semantics:

- Standalone gas cooktops (e.g. Monogram ZGU36ESLSS, `DEVICE_GATEWAY_V1_BLE_ADVERTISE_ONLY_SENSOR` feature flag) emit `0x5520` as a simple cooktop-on aggregate byte, but upstream decodes `0x5520` as `COOKTOP_STATUS` with per-burner `CooktopStatus(...)` semantics that are meaningless on the gas cooktop.
- Same device emits `0x5105` as raw `uint16` kitchen-timer minutes; upstream decodes `0x5105` as `UPPER_OVEN_KITCHEN_TIMER` (`timedelta` seconds).
- Same device emits `0x5020` with a simple alarm byte; upstream decodes `0x5020` as `HOOD_TIMER`.

Downstream integrations today have no way to get at the raw bytes after the global converter has run — the decoded value is already the wrong shape.

## Fix

Preserve the raw hex string for every ERD in a parallel cache and expose it via a new `GeAppliance.get_raw_erd_value()` method:

- ~15 LOC
- Additive only, no breaking change
- No new dependencies
- Existing decoded cache and all existing callers unchanged
- 4 new unit tests

## Usage (downstream)

```python
appliance.update_erd_value("0x5520", "00FFFFFFFFFFFFFFFFFFFFFFFF")
# Upstream: CooktopStatus(all-burners-0xFF) — meaningless on gas cooktop
appliance.get_erd_value("0x5520")
# New: raw bytes available for the consumer to decode per the device's actual schema
appliance.get_raw_erd_value("0x5520")  # -> "00FFFFFFFFFFFFFFFFFFFFFFFF"
```

## Context

This is Phase 1 of adding `GAS_COOKTOP` (`ErdApplianceType.GAS_COOKTOP = "0D"`) support to `ha_gehome` — see sibling issues [simbaja/ha_gehome#305](https://github.com/simbaja/ha_gehome/issues/305) (F&P cooktop unmapped) and [simbaja/ha_gehome#482](https://github.com/simbaja/ha_gehome/issues/482) (Café gas range cooktop sensors stuck off). Phase 2 would be an `ha_gehome` PR adding a `GasCooktopApi` device handler that uses `get_raw_erd_value()` to decode the cooktop-specific bytes. I'll file that PR if/when this one lands.

Tested end-to-end against a live ZGU36ESLSS running a local backport of this change for 2+ days.
